### PR TITLE
fix: span gradient background to full width of the screen

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -60,7 +60,7 @@ export default function RootLayout({
                             background:
                                 "linear-gradient(45deg, #3b82f6 0%, #8b5cf6 50%, #ec4899 100%)",
                         }}
-                        className="max-w-7xl mx-auto py-6 sm:px-6 lg:px-8 px-4 min-h-[70vh]"
+                        className="w-full mx-auto py-6 sm:px-6 lg:px-8 px-4 min-h-[70vh]"
                     >
                         {children}
                     </div>


### PR DESCRIPTION
# Description

Set the gradient background to have full width of the screen

Fixes Issue #271 
## Type of change

- Bug fix


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
